### PR TITLE
require webpack and webpack-middlewares only when not in production

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,17 @@
-/* eslint-disable import/no-unresolved */
-const Webpack = require('webpack');
-const WebpackDevMiddleware = require('webpack-dev-middleware');
-const WebpackHotMiddleware = require('webpack-hot-middleware');
-/* eslint-enable import/no-unresolved */
+const Webpack = require('webpack'); // eslint-disable-line import/no-unresolved
 const pkg = require('../package.json');
 
 exports.register = function register(server, options, next) {
   if (process.env.NODE_ENV === 'production') {
     return next();
   }
+
+  /* eslint-disable import/no-unresolved  */
+  /* eslint-disable global-require  */
+  const WebpackDevMiddleware = require('webpack-dev-middleware');
+  const WebpackHotMiddleware = require('webpack-hot-middleware');
+  /* eslint-disable global-require  */
+  /* eslint-enable import/no-unresolved */
 
   const webpackConfig = options.webpack || {};
   const webpackDevConfig = options.webpackDev || {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ exports.register = function register(server, options, next) {
   /* eslint-enable new-cap */
 
   server.ext('onRequest', (request, reply) => {
-    const { req, res } = request.raw;
+    const req = request.raw.req;
+    const res = request.raw.res;
 
     webpackDevMiddleware(req, res, error => {
       if (error) {
@@ -33,7 +34,8 @@ exports.register = function register(server, options, next) {
   });
 
   server.ext('onRequest', (request, reply) => {
-    const { req, res } = request.raw;
+    const req = request.raw.req;
+    const res = request.raw.res;
 
     webpackHotMiddleware(req, res, error => {
       if (error) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-const Webpack = require('webpack'); // eslint-disable-line import/no-unresolved
 const pkg = require('../package.json');
 
 exports.register = function register(server, options, next) {
@@ -8,6 +7,7 @@ exports.register = function register(server, options, next) {
 
   /* eslint-disable import/no-unresolved  */
   /* eslint-disable global-require  */
+  const Webpack = require('webpack');
   const WebpackDevMiddleware = require('webpack-dev-middleware');
   const WebpackHotMiddleware = require('webpack-hot-middleware');
   /* eslint-disable global-require  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,30 +20,25 @@ exports.register = function register(server, options, next) {
   const webpackHotMiddleware = WebpackHotMiddleware(compiler, webpackHotConfig);
   /* eslint-enable new-cap */
 
-  server.ext('onRequest', (request, reply) => {
-    const req = request.raw.req;
-    const res = request.raw.res;
+  function addMiddleware(middleware, raw, reply) {
+    const req = raw.req;
+    const res = raw.res;
 
-    webpackDevMiddleware(req, res, error => {
+    middleware(req, res, error => {
       if (error) {
         return reply(error);
       }
 
       return reply.continue();
     });
+  }
+
+  server.ext('onRequest', (request, reply) => {
+    addMiddleware(webpackDevMiddleware, request.raw, reply);
   });
 
   server.ext('onRequest', (request, reply) => {
-    const req = request.raw.req;
-    const res = request.raw.res;
-
-    webpackHotMiddleware(req, res, error => {
-      if (error) {
-        return reply(error);
-      }
-
-      return reply.continue();
-    });
+    addMiddleware(webpackHotMiddleware, request.raw, reply);
   });
 
   return next();


### PR DESCRIPTION
require webpack and co only when not in production.
if you start your node-app in production and you have your middlewares in devDependencies, it would fail :crying_cat_face: 

it should now fix this behavior 
